### PR TITLE
feat: implement streaming chat with tool execution (Phase 1)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,11 @@
       "name": "slc-ai-advisor",
       "version": "0.1.0",
       "dependencies": {
+        "@ai-sdk/anthropic": "^3.0.1",
+        "@ai-sdk/react": "^3.0.3",
         "@anthropic-ai/sdk": "^0.71.2",
         "agents": "^0.3.0",
+        "ai": "^6.0.3",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-markdown": "^10.1.0",
@@ -28,16 +31,30 @@
         "wrangler": "^4.56.0"
       }
     },
-    "node_modules/@ai-sdk/gateway": {
+    "node_modules/@ai-sdk/anthropic": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.1.tgz",
-      "integrity": "sha512-WyDeUe59k55lhAXAxsfdYi28IANwpAEzt8AtdA332uWPZliRfd/ccIEzMdeCuG9Z45TFMVmR1TMAenDnnJ0leQ==",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/anthropic/-/anthropic-3.0.1.tgz",
+      "integrity": "sha512-MOiwKs76ilEmau/WRMnGWlheTUoB+cbvXCse+SAtpW5ATLreInsuYlspLABn12Dxu3w1Xzke1dT+tmEnxhy9SA==",
       "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "@ai-sdk/provider": "3.0.0",
-        "@ai-sdk/provider-utils": "4.0.0",
+        "@ai-sdk/provider-utils": "4.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/gateway": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.2.tgz",
+      "integrity": "sha512-giJEg9ob45htbu3iautK+2kvplY2JnTj7ir4wZzYSQWvqGatWfBBfDuNCU5wSJt9BCGjymM5ZS9ziD42JGCZBw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.0",
+        "@ai-sdk/provider-utils": "4.0.1",
         "@vercel/oidc": "3.0.5"
       },
       "engines": {
@@ -52,8 +69,6 @@
       "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.0.tgz",
       "integrity": "sha512-m9ka3ptkPQbaHHZHqDXDF9C9B5/Mav0KTdky1k2HZ3/nrW2t1AgObxIVPyGDWQNS9FXT/FS6PIoSjpcP/No8rQ==",
       "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "json-schema": "^0.4.0"
       },
@@ -62,12 +77,10 @@
       }
     },
     "node_modules/@ai-sdk/provider-utils": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.0.tgz",
-      "integrity": "sha512-HyCyOls9I3a3e38+gtvOJOEjuw9KRcvbBnCL5GBuSmJvS9Jh9v3fz7pRC6ha1EUo/ZH1zwvLWYXBMtic8MTguA==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.1.tgz",
+      "integrity": "sha512-de2v8gH9zj47tRI38oSxhQIewmNc+OZjYIOOaMoVWKL65ERSav2PYYZHPSPCrfOeLMkv+Dyh8Y0QGwkO29wMWQ==",
       "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "@ai-sdk/provider": "3.0.0",
         "@standard-schema/spec": "^1.1.0",
@@ -81,15 +94,13 @@
       }
     },
     "node_modules/@ai-sdk/react": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/react/-/react-3.0.2.tgz",
-      "integrity": "sha512-9ar3S4JnK/lBX2BcTSrRXlhYZ6nm0hjjoB9atz1B3lbciWxHXdAbZlhlcOpgSkNpgreD14eFaiGrQ8uSgYJzEQ==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/react/-/react-3.0.3.tgz",
+      "integrity": "sha512-mLIgQuBdIX9gxCYQN3Pv/J8ARoFreIKYr/TVQtI+FwEzejuGFimTyhDln7UIBfrnm3Mpn1xENIWZfDfCRF7wkw==",
       "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
       "dependencies": {
-        "@ai-sdk/provider-utils": "4.0.0",
-        "ai": "6.0.2",
+        "@ai-sdk/provider-utils": "4.0.1",
+        "ai": "6.0.3",
         "swr": "^2.2.5",
         "throttleit": "2.1.0"
       },
@@ -1581,8 +1592,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -1962,9 +1971,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -2107,8 +2114,6 @@
       "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.0.5.tgz",
       "integrity": "sha512-fnYhv671l+eTTp48gB4zEsTW/YtRgRPnkI2nT7x6qw5rkI1Lq2hTmQIpHPgyThI0znLK+vX2n9XxKdXZ7BUbbw==",
       "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
       "engines": {
         "node": ">= 20"
       }
@@ -2237,16 +2242,14 @@
       }
     },
     "node_modules/ai": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.2.tgz",
-      "integrity": "sha512-LQYfHOBYDAm5y6KI6qM9WG056q8gzyfXoFxx607uHxjFGdboNqU58JpxBoo91XRJdpI/K70Qxa4VFcsWjkn9vA==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.3.tgz",
+      "integrity": "sha512-OOo+/C+sEyscoLnbY3w42vjQDICioVNyS+F+ogwq6O5RJL/vgWGuiLzFwuP7oHTeni/MkmX8tIge48GTdaV7QQ==",
       "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
       "dependencies": {
-        "@ai-sdk/gateway": "3.0.1",
+        "@ai-sdk/gateway": "3.0.2",
         "@ai-sdk/provider": "3.0.0",
-        "@ai-sdk/provider-utils": "4.0.0",
+        "@ai-sdk/provider-utils": "4.0.1",
         "@opentelemetry/api": "1.9.0"
       },
       "engines": {
@@ -5392,8 +5395,6 @@
       "resolved": "https://registry.npmjs.org/swr/-/swr-2.3.8.tgz",
       "integrity": "sha512-gaCPRVoMq8WGDcWj9p4YWzCMPHzE0WNl6W8ADIx9c3JBEIdMkJGMzW+uzXvxHMltwcYACr9jP+32H8/hgwMR7w==",
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "dequal": "^2.0.3",
         "use-sync-external-store": "^1.6.0"
@@ -5407,8 +5408,6 @@
       "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-2.1.0.tgz",
       "integrity": "sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==",
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -5654,8 +5653,6 @@
       "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
       "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -28,8 +28,11 @@
     "wrangler": "^4.56.0"
   },
   "dependencies": {
+    "@ai-sdk/anthropic": "^3.0.1",
+    "@ai-sdk/react": "^3.0.3",
     "@anthropic-ai/sdk": "^0.71.2",
     "agents": "^0.3.0",
+    "ai": "^6.0.3",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-markdown": "^10.1.0",

--- a/src/components/Canvas.tsx
+++ b/src/components/Canvas.tsx
@@ -9,7 +9,7 @@ import {
 } from '../types/canvas';
 
 interface CanvasProps {
-  sessionId: string;
+  canvasId: string;
 }
 
 /**
@@ -42,9 +42,9 @@ const SECTION_HELPER_TEXT: Record<CanvasSectionId, string> = {
  * The Social Lean Canvas with official layout.
  * Layout matches socialleancanvas.com
  */
-export function Canvas({ sessionId }: CanvasProps) {
+export function Canvas({ canvasId }: CanvasProps) {
   const [sections, setSections] = useState(() =>
-    createEmptySections(sessionId).reduce(
+    createEmptySections(canvasId).reduce(
       (acc, section) => {
         acc[section.sectionKey] = section.content;
         return acc;
@@ -54,7 +54,7 @@ export function Canvas({ sessionId }: CanvasProps) {
   );
 
   const [impactModel, setImpactModel] = useState<ImpactModel>(() =>
-    createEmptyImpactModel(sessionId)
+    createEmptyImpactModel(canvasId)
   );
 
   const [showImpactPanel, setShowImpactPanel] = useState(false);

--- a/src/components/ConnectionStatus.tsx
+++ b/src/components/ConnectionStatus.tsx
@@ -1,0 +1,27 @@
+/**
+ * WebSocket connection status indicator
+ *
+ * Displays the current connection state of the agent WebSocket.
+ */
+
+interface ConnectionStatusProps {
+  readyState: number;
+}
+
+const STATUS_CONFIG: Record<number, { label: string; className: string }> = {
+  0: { label: 'Connecting...', className: 'connecting' },
+  1: { label: 'Connected', className: 'connected' },
+  2: { label: 'Closing', className: 'closing' },
+  3: { label: 'Disconnected', className: 'disconnected' },
+};
+
+export function ConnectionStatus({ readyState }: ConnectionStatusProps) {
+  const status = STATUS_CONFIG[readyState] || { label: 'Unknown', className: 'unknown' };
+
+  return (
+    <div className={`connection-status connection-${status.className}`}>
+      <span className="connection-dot" aria-hidden="true" />
+      <span className="connection-label">{status.label}</span>
+    </div>
+  );
+}

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -1,0 +1,20 @@
+/**
+ * Agent status bar
+ *
+ * Shows what the agent is currently doing (thinking, searching, updating).
+ * Uses CSS-based indicators instead of emojis per project guidelines.
+ */
+
+interface StatusBarProps {
+  status: 'thinking' | 'searching' | 'updating' | 'error';
+  message: string;
+}
+
+export function StatusBar({ status, message }: StatusBarProps) {
+  return (
+    <div className={`status-bar status-${status}`}>
+      <span className="status-indicator" aria-hidden="true" />
+      <span className="status-message">{message}</span>
+    </div>
+  );
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,4 +1,6 @@
 export { Canvas } from './Canvas';
 export { CanvasSection } from './CanvasSection';
 export { Chat } from './Chat';
+export { ConnectionStatus } from './ConnectionStatus';
 export { ImpactPanel } from './ImpactPanel';
+export { StatusBar } from './StatusBar';

--- a/src/index.css
+++ b/src/index.css
@@ -366,6 +366,13 @@ body {
   min-height: 0;
 }
 
+.chat-header {
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--border-color);
+  display: flex;
+  justify-content: flex-end;
+}
+
 .chat-messages {
   flex: 1;
   overflow-y: auto;
@@ -656,6 +663,94 @@ body {
   background: var(--accent-color);
   border: none;
   color: white;
+}
+
+/* ============================================
+   Connection Status
+   ============================================ */
+
+.connection-status {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  font-size: 0.75rem;
+  border-radius: 4px;
+  background: var(--bg-tertiary);
+}
+
+.connection-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+}
+
+.connection-connecting .connection-dot {
+  background: #eab308;
+  animation: pulse 1.5s ease-in-out infinite;
+}
+
+.connection-connected .connection-dot {
+  background: #22c55e;
+}
+
+.connection-closing .connection-dot {
+  background: #f97316;
+}
+
+.connection-disconnected .connection-dot {
+  background: #ef4444;
+}
+
+.connection-unknown .connection-dot {
+  background: #6b7280;
+}
+
+/* ============================================
+   Status Bar
+   ============================================ */
+
+.status-bar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  font-size: 0.85rem;
+  background: var(--bg-tertiary);
+  border-bottom: 1px solid var(--border-color);
+}
+
+.status-indicator {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  animation: pulse 1.5s ease-in-out infinite;
+}
+
+.status-thinking .status-indicator {
+  background: #3b82f6;
+}
+
+.status-searching .status-indicator {
+  background: #8b5cf6;
+}
+
+.status-updating .status-indicator {
+  background: #10b981;
+}
+
+.status-error .status-indicator {
+  background: #ef4444;
+  animation: none;
+}
+
+.status-message {
+  color: var(--text-secondary);
+}
+
+@keyframes pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.4; }
 }
 
 /* ============================================

--- a/worker/agents/anthropic-tools.ts
+++ b/worker/agents/anthropic-tools.ts
@@ -1,0 +1,216 @@
+/**
+ * Anthropic-format tool definitions for SLCAgent
+ *
+ * Converts our tool definitions to Anthropic's expected format
+ * and provides execution handlers.
+ */
+
+import type Anthropic from '@anthropic-ai/sdk';
+import type { CanvasDO } from '../durable-objects/CanvasDO';
+import type { AgentState } from './SLCAgent';
+
+/**
+ * Context interface for tool execution
+ */
+export interface ToolContext {
+  name: string; // Agent instance name = canvasId
+  state: AgentState; // Property getter from AIChatAgent
+  setState(state: AgentState): void;
+  getCanvasStub(canvasId: string): DurableObjectStub<CanvasDO>;
+}
+
+/**
+ * Tool definitions in Anthropic format
+ */
+export const ANTHROPIC_TOOLS: Anthropic.Tool[] = [
+  {
+    name: 'update_purpose',
+    description:
+      'Update the Purpose section of the canvas. Purpose should explain why the venture exists and what problem it solves.',
+    input_schema: {
+      type: 'object' as const,
+      properties: {
+        content: {
+          type: 'string',
+          description: 'The purpose content explaining why the venture exists',
+        },
+      },
+      required: ['content'],
+    },
+  },
+  {
+    name: 'update_customer_section',
+    description:
+      'Update a Customer Model section: customers (who you serve), jobsToBeDone (their problems), valueProposition (your unique solution), or solution (your product/service).',
+    input_schema: {
+      type: 'object' as const,
+      properties: {
+        section: {
+          type: 'string',
+          enum: ['customers', 'jobsToBeDone', 'valueProposition', 'solution'],
+          description: 'Which customer model section to update',
+        },
+        content: {
+          type: 'string',
+          description: 'The content for this section',
+        },
+      },
+      required: ['section', 'content'],
+    },
+  },
+  {
+    name: 'update_economic_section',
+    description:
+      'Update an Economic Model section: channels (how you reach customers), revenue (how you make money), costs (major expenses), or advantage (competitive moat).',
+    input_schema: {
+      type: 'object' as const,
+      properties: {
+        section: {
+          type: 'string',
+          enum: ['channels', 'revenue', 'costs', 'advantage'],
+          description: 'Which economic model section to update',
+        },
+        content: {
+          type: 'string',
+          description: 'The content for this section',
+        },
+      },
+      required: ['section', 'content'],
+    },
+  },
+  {
+    name: 'update_impact_field',
+    description:
+      'Update an Impact Model field in the causality chain. The chain flows: issue -> participants -> activities -> outputs -> shortTermOutcomes -> mediumTermOutcomes -> longTermOutcomes -> impact.',
+    input_schema: {
+      type: 'object' as const,
+      properties: {
+        field: {
+          type: 'string',
+          enum: [
+            'issue',
+            'participants',
+            'activities',
+            'outputs',
+            'shortTermOutcomes',
+            'mediumTermOutcomes',
+            'longTermOutcomes',
+            'impact',
+          ],
+          description: 'Which impact model field to update',
+        },
+        content: {
+          type: 'string',
+          description: 'The content for this field',
+        },
+      },
+      required: ['field', 'content'],
+    },
+  },
+  {
+    name: 'update_key_metrics',
+    description:
+      'Update the Key Metrics section. This should be completed last, after other sections are filled in.',
+    input_schema: {
+      type: 'object' as const,
+      properties: {
+        content: {
+          type: 'string',
+          description: 'The key metrics content',
+        },
+      },
+      required: ['content'],
+    },
+  },
+  {
+    name: 'get_canvas',
+    description:
+      'Get the current canvas state to understand what has been filled in and what is missing.',
+    input_schema: {
+      type: 'object' as const,
+      properties: {},
+      required: [],
+    },
+  },
+];
+
+/**
+ * Execute a tool and return the result
+ */
+export async function executeTool(
+  ctx: ToolContext,
+  toolName: string,
+  toolInput: Record<string, unknown>
+): Promise<unknown> {
+  const canvasId = ctx.name;
+  if (!canvasId) {
+    throw new Error('No canvas selected. Please create or select a canvas first.');
+  }
+
+  const stub = ctx.getCanvasStub(canvasId);
+
+  const setStatus = (status: AgentState['status'], message: string) => {
+    ctx.setState({ ...ctx.state, status, statusMessage: message });
+  };
+
+  switch (toolName) {
+    case 'update_purpose': {
+      setStatus('updating', 'Updating purpose...');
+      const result = await stub.updateSection('purpose', toolInput.content as string);
+      return result;
+    }
+
+    case 'update_customer_section': {
+      const section = toolInput.section as string;
+      setStatus('updating', `Updating ${section}...`);
+      const result = await stub.updateSection(
+        section as 'customers' | 'jobsToBeDone' | 'valueProposition' | 'solution',
+        toolInput.content as string
+      );
+      return result;
+    }
+
+    case 'update_economic_section': {
+      const section = toolInput.section as string;
+      setStatus('updating', `Updating ${section}...`);
+      const result = await stub.updateSection(
+        section as 'channels' | 'revenue' | 'costs' | 'advantage',
+        toolInput.content as string
+      );
+      return result;
+    }
+
+    case 'update_impact_field': {
+      const field = toolInput.field as string;
+      setStatus('updating', `Updating impact ${field}...`);
+      const result = await stub.updateImpactField(
+        field as
+          | 'issue'
+          | 'participants'
+          | 'activities'
+          | 'outputs'
+          | 'shortTermOutcomes'
+          | 'mediumTermOutcomes'
+          | 'longTermOutcomes'
+          | 'impact',
+        toolInput.content as string
+      );
+      return result;
+    }
+
+    case 'update_key_metrics': {
+      setStatus('updating', 'Updating key metrics...');
+      const result = await stub.updateSection('keyMetrics', toolInput.content as string);
+      return result;
+    }
+
+    case 'get_canvas': {
+      setStatus('searching', 'Loading canvas...');
+      const canvas = await stub.getFullCanvas();
+      return canvas;
+    }
+
+    default:
+      throw new Error(`Unknown tool: ${toolName}`);
+  }
+}

--- a/worker/agents/prompts.ts
+++ b/worker/agents/prompts.ts
@@ -1,0 +1,137 @@
+/**
+ * System prompts for SLCAgent
+ *
+ * Templates for AI conversation context.
+ */
+
+export const SYSTEM_PROMPT = `You are an AI advisor helping social entrepreneurs build their Social Lean Canvas.
+
+## Your Role
+- Guide users through the 11 canvas sections
+- Help them articulate their social venture clearly
+- Update canvas sections using the provided tools when the user provides content
+
+## The Social Lean Canvas Framework
+The canvas has 11 sections organized into 3 models:
+
+**Customer Model:**
+- Customers: Who are you serving?
+- Jobs To Be Done: What problems do they need solved?
+- Value Proposition: How do you uniquely solve their problems?
+- Solution: What is your product/service?
+
+**Economic Model:**
+- Channels: How do you reach customers?
+- Revenue: How do you make money?
+- Costs: What are your major expenses?
+- Advantage: What makes you hard to copy?
+
+**Impact Model (8-field causality chain):**
+Issue → Participants → Activities → Outputs → Short-term Outcomes → Medium-term Outcomes → Long-term Outcomes → Impact
+
+**Cross-cutting Sections:**
+- Purpose: Why does your venture exist? (Complete first)
+- Key Metrics: How do you measure success? (Complete last)
+
+## Current Canvas Context
+{canvasContext}
+
+## Guidelines
+- Ask clarifying questions before updating sections
+- Suggest one section to work on at a time
+- When the user provides content, use the appropriate update tool
+- Reference the impact model when discussing social outcomes
+- Be encouraging but honest about gaps in the canvas
+- Keep responses concise and actionable
+`;
+
+/**
+ * Format canvas state for inclusion in system prompt
+ */
+export function formatCanvasContext(canvas: {
+  purpose?: string;
+  customers?: string;
+  jobsToBeDone?: string;
+  valueProposition?: string;
+  solution?: string;
+  channels?: string;
+  revenue?: string;
+  costs?: string;
+  advantage?: string;
+  keyMetrics?: string;
+  impactModel?: {
+    issue?: string;
+    participants?: string;
+    activities?: string;
+    outputs?: string;
+    shortTermOutcomes?: string;
+    mediumTermOutcomes?: string;
+    longTermOutcomes?: string;
+    impact?: string;
+  };
+} | null): string {
+  if (!canvas) {
+    return 'No canvas selected. The user should create or select a canvas first.';
+  }
+
+  const sections: string[] = [];
+
+  // Purpose (first)
+  if (canvas.purpose) {
+    sections.push(`**Purpose:** ${canvas.purpose}`);
+  } else {
+    sections.push(`**Purpose:** (not yet defined - suggest starting here)`);
+  }
+
+  // Customer Model
+  const customerSections = [
+    canvas.customers ? `- Customers: ${canvas.customers}` : '- Customers: (empty)',
+    canvas.jobsToBeDone ? `- Jobs To Be Done: ${canvas.jobsToBeDone}` : '- Jobs To Be Done: (empty)',
+    canvas.valueProposition ? `- Value Proposition: ${canvas.valueProposition}` : '- Value Proposition: (empty)',
+    canvas.solution ? `- Solution: ${canvas.solution}` : '- Solution: (empty)',
+  ];
+  sections.push(`\n**Customer Model:**\n${customerSections.join('\n')}`);
+
+  // Economic Model
+  const economicSections = [
+    canvas.channels ? `- Channels: ${canvas.channels}` : '- Channels: (empty)',
+    canvas.revenue ? `- Revenue: ${canvas.revenue}` : '- Revenue: (empty)',
+    canvas.costs ? `- Costs: ${canvas.costs}` : '- Costs: (empty)',
+    canvas.advantage ? `- Advantage: ${canvas.advantage}` : '- Advantage: (empty)',
+  ];
+  sections.push(`\n**Economic Model:**\n${economicSections.join('\n')}`);
+
+  // Impact Model
+  if (canvas.impactModel) {
+    const im = canvas.impactModel;
+    const impactFields = [
+      im.issue ? `- Issue: ${im.issue}` : '- Issue: (empty)',
+      im.participants ? `- Participants: ${im.participants}` : '- Participants: (empty)',
+      im.activities ? `- Activities: ${im.activities}` : '- Activities: (empty)',
+      im.outputs ? `- Outputs: ${im.outputs}` : '- Outputs: (empty)',
+      im.shortTermOutcomes ? `- Short-term Outcomes: ${im.shortTermOutcomes}` : '- Short-term Outcomes: (empty)',
+      im.mediumTermOutcomes ? `- Medium-term Outcomes: ${im.mediumTermOutcomes}` : '- Medium-term Outcomes: (empty)',
+      im.longTermOutcomes ? `- Long-term Outcomes: ${im.longTermOutcomes}` : '- Long-term Outcomes: (empty)',
+      im.impact ? `- Impact: ${im.impact}` : '- Impact: (empty)',
+    ];
+    sections.push(`\n**Impact Model:**\n${impactFields.join('\n')}`);
+  } else {
+    sections.push('\n**Impact Model:** (not started)');
+  }
+
+  // Key Metrics (last)
+  if (canvas.keyMetrics) {
+    sections.push(`\n**Key Metrics:** ${canvas.keyMetrics}`);
+  } else {
+    sections.push('\n**Key Metrics:** (complete after other sections)');
+  }
+
+  return sections.join('\n');
+}
+
+/**
+ * Build system prompt with canvas context
+ */
+export function buildSystemPrompt(canvasContext: string): string {
+  return SYSTEM_PROMPT.replace('{canvasContext}', canvasContext);
+}

--- a/worker/durable-objects/CanvasDO.ts
+++ b/worker/durable-objects/CanvasDO.ts
@@ -410,6 +410,21 @@ export class CanvasDO extends DurableObject<Env> {
   }
 
   /**
+   * Update an Impact Model field directly
+   *
+   * Routes to ImpactModelManager for field updates.
+   * Fields: issue, participants, activities, outputs,
+   * shortTermOutcomes, mediumTermOutcomes, longTermOutcomes, impact
+   */
+  async updateImpactField(
+    field: string,
+    content: string
+  ): Promise<UpdateResult> {
+    await this.ensureInitialized();
+    return this.impactManager.updateSection(field, content);
+  }
+
+  /**
    * Get overall canvas completion
    */
   private async getOverallCompletion(): Promise<ModelCompletion> {

--- a/worker/env.d.ts
+++ b/worker/env.d.ts
@@ -7,9 +7,10 @@ declare global {
     // API Keys
     ANTHROPIC_API_KEY: string;
 
-    // AI Gateway configuration (optional)
-    CF_ACCOUNT_ID?: string;
-    CF_GATEWAY_ID?: string;
+    // AI Gateway configuration (required for SLCAgent)
+    CF_ACCOUNT_ID: string;
+    CF_GATEWAY_ID: string;
+    CF_AIG_TOKEN?: string; // Optional: Required if Authenticated Gateway is enabled
 
     // Static assets
     ASSETS: Fetcher;

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -56,6 +56,8 @@ binding = "AI"
 
 # Environment Variables (set via wrangler secret or dashboard)
 # ANTHROPIC_API_KEY - Set via: wrangler secret put ANTHROPIC_API_KEY
+# CF_ACCOUNT_ID - Set via: wrangler secret put CF_ACCOUNT_ID
+# CF_GATEWAY_ID - Set via: wrangler secret put CF_GATEWAY_ID
 
 # Development
 [dev]


### PR DESCRIPTION
## Summary

Implements the backend portion of Phase 1 (Issue #36): streaming chat with tool execution for SLCAgent.

### Key Changes

- **Streaming via Anthropic SDK**: Uses `@anthropic-ai/sdk` directly through AI Gateway (not Vercel AI SDK's `@ai-sdk/anthropic` due to auth issues)
- **Multi-step tool execution**: Up to 5 steps of tool calls with results fed back to Claude
- **Real-time status updates**: Agent status syncs to frontend via `setState()`
- **Canvas context**: System prompt includes current canvas state

### New Files

| File | Purpose |
|------|---------|
| `worker/agents/prompts.ts` | System prompt templates with canvas context formatting |
| `worker/agents/anthropic-tools.ts` | Anthropic-format tool definitions + execution handler |
| `src/components/ConnectionStatus.tsx` | WebSocket connection status indicator |
| `src/components/StatusBar.tsx` | Agent status display (CSS indicators, no emojis) |

### Available Tools

- `update_purpose` - Update Purpose section
- `update_customer_section` - Update customers/jobsToBeDone/valueProposition/solution
- `update_economic_section` - Update channels/revenue/costs/advantage
- `update_impact_field` - Update 8-field impact causality chain
- `update_key_metrics` - Update Key Metrics section
- `get_canvas` - Fetch current canvas state

### Environment Requirements

```bash
ANTHROPIC_API_KEY=sk-ant-...
CF_ACCOUNT_ID=your-account-id
CF_GATEWAY_ID=your-gateway-id
CF_AIG_TOKEN=your-aig-token  # Optional: Required if Authenticated Gateway is enabled
```

## Test plan

- [x] TypeScript typecheck passes
- [x] Streaming displays progressively (not all at once)
- [x] Tool detection works (logs: "Tool use detected")
- [x] Tool execution works (logs: "Executing tool: get_canvas")
- [x] Multi-step works (Step 1 -> tool -> Step 2)
- [ ] Frontend canvas sync (tracked in #44)

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)