### PR TITLE
feat: unified canvas and knowledge tools

### DIFF
--- a/worker/env.d.ts
+++ b/worker/env.d.ts
@@ -21,6 +21,12 @@ declare global {
 
     // Analytics Engine for metrics
     SLC_ANALYTICS: AnalyticsEngineDataset;
+
+    // Vectorize for knowledge base search
+    VECTORIZE: Vectorize;
+
+    // AI for embeddings
+    AI: Ai;
   }
 }
 


### PR DESCRIPTION
## Summary

Combines canvas tools (#38) and knowledge tools (#39) into unified anthropic-tools.ts:

- **Canvas tools (6)**: `update_purpose`, `update_customer_section`, `update_economic_section`, `update_impact_field`, `update_key_metrics`, `get_canvas`
- **Knowledge tools (4)**: `search_methodology`, `search_examples`, `search_knowledge_base`, `get_venture_profile`

Key implementation details:
- Uses Vectorize with `@cf/baai/bge-m3` for 1024-dim embeddings
- Selection Matrix metadata filtering for contextual example search
- Extended ToolContext with `env` for Vectorize/AI bindings
- Added `VECTORIZE` and `AI` bindings to env.d.ts

## Related Issues

Closes #38 (Canvas Tools)
Closes #39 (Knowledge Tools)

## Test plan

- [ ] Run `npm run typecheck` - passes
- [ ] Verify tool definitions match Anthropic format
- [ ] Test canvas tool execution via chat
- [ ] Test knowledge search with metadata filters (requires populated Vectorize index)

🤖 Generated with [Claude Code](https://claude.com/claude-code)