### PR TITLE
feat: canvas save state tracking and empty canvas handling

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, Component, ReactNode } from 'react';
 import { Canvas, Chat } from './components';
+import { CanvasProvider } from './context';
 
 /**
  * Error boundary to catch and display React errors
@@ -143,31 +144,33 @@ function App() {
 
   return (
     <ErrorBoundary>
-      <div className="app">
-        <header className="app-header">
-          <h1>SLC AI Advisor</h1>
-          <div className="app-header-actions">
-            <button
-              className="theme-toggle"
-              onClick={toggleTheme}
-              title={`Switch to ${theme === 'light' ? 'dark' : 'light'} mode`}
-            >
-              {theme === 'light' ? 'Dark' : 'Light'}
-            </button>
-          </div>
-        </header>
+      <CanvasProvider>
+        <div className="app">
+          <header className="app-header">
+            <h1>SLC AI Advisor</h1>
+            <div className="app-header-actions">
+              <button
+                className="theme-toggle"
+                onClick={toggleTheme}
+                title={`Switch to ${theme === 'light' ? 'dark' : 'light'} mode`}
+              >
+                {theme === 'light' ? 'Dark' : 'Light'}
+              </button>
+            </div>
+          </header>
 
-        <main className="app-main">
-          <div className="layout-canvas">
-            <Canvas canvasId={canvasId} />
-          </div>
-          <div className="layout-chat">
-            <ErrorBoundary>
-              <Chat canvasId={canvasId} />
-            </ErrorBoundary>
-          </div>
-        </main>
-      </div>
+          <main className="app-main">
+            <div className="layout-canvas">
+              <Canvas canvasId={canvasId} />
+            </div>
+            <div className="layout-chat">
+              <ErrorBoundary>
+                <Chat canvasId={canvasId} />
+              </ErrorBoundary>
+            </div>
+          </main>
+        </div>
+      </CanvasProvider>
     </ErrorBoundary>
   );
 }

--- a/src/components/CanvasSkeleton.tsx
+++ b/src/components/CanvasSkeleton.tsx
@@ -1,0 +1,159 @@
+/**
+ * Skeleton loading state for the Social Lean Canvas.
+ * Matches the exact layout of the Canvas component with pulsing placeholders.
+ */
+export function CanvasSkeleton() {
+  return (
+    <div className="slc-canvas skeleton">
+      {/* Top Row: Purpose & Impact */}
+      <div className="slc-row slc-row-top">
+        <div className="canvas-section skeleton-block">
+          <div className="canvas-section-header">
+            <span className="skeleton-text skeleton-number" />
+            <span className="skeleton-text skeleton-title" />
+          </div>
+          <div className="skeleton-content">
+            <span className="skeleton-line" />
+            <span className="skeleton-line" />
+            <span className="skeleton-line short" />
+          </div>
+        </div>
+        <div className="canvas-section skeleton-block">
+          <div className="canvas-section-header">
+            <span className="skeleton-text skeleton-number" />
+            <span className="skeleton-text skeleton-title" />
+          </div>
+          <div className="skeleton-content">
+            <span className="skeleton-line" />
+            <span className="skeleton-line" />
+          </div>
+        </div>
+      </div>
+
+      {/* Middle Section: 5-column layout */}
+      <div className="slc-row slc-row-middle">
+        {/* Column 1: Jobs To Be Done (double height) */}
+        <div className="slc-col slc-col-double">
+          <div className="canvas-section skeleton-block">
+            <div className="canvas-section-header">
+              <span className="skeleton-text skeleton-number" />
+              <span className="skeleton-text skeleton-title" />
+            </div>
+            <div className="skeleton-content">
+              <span className="skeleton-line" />
+              <span className="skeleton-line" />
+              <span className="skeleton-line" />
+              <span className="skeleton-line short" />
+            </div>
+          </div>
+        </div>
+
+        {/* Column 2: Solution + Key Metrics (stacked) */}
+        <div className="slc-col slc-col-stacked">
+          <div className="canvas-section skeleton-block">
+            <div className="canvas-section-header">
+              <span className="skeleton-text skeleton-number" />
+              <span className="skeleton-text skeleton-title" />
+            </div>
+            <div className="skeleton-content">
+              <span className="skeleton-line" />
+              <span className="skeleton-line short" />
+            </div>
+          </div>
+          <div className="canvas-section skeleton-block">
+            <div className="canvas-section-header">
+              <span className="skeleton-text skeleton-number" />
+              <span className="skeleton-text skeleton-title" />
+            </div>
+            <div className="skeleton-content">
+              <span className="skeleton-line" />
+              <span className="skeleton-line short" />
+            </div>
+          </div>
+        </div>
+
+        {/* Column 3: Value Proposition (double height) */}
+        <div className="slc-col slc-col-double">
+          <div className="canvas-section skeleton-block">
+            <div className="canvas-section-header">
+              <span className="skeleton-text skeleton-number" />
+              <span className="skeleton-text skeleton-title" />
+            </div>
+            <div className="skeleton-content">
+              <span className="skeleton-line" />
+              <span className="skeleton-line" />
+              <span className="skeleton-line" />
+              <span className="skeleton-line short" />
+            </div>
+          </div>
+        </div>
+
+        {/* Column 4: Advantage + Channels (stacked) */}
+        <div className="slc-col slc-col-stacked">
+          <div className="canvas-section skeleton-block">
+            <div className="canvas-section-header">
+              <span className="skeleton-text skeleton-number" />
+              <span className="skeleton-text skeleton-title" />
+            </div>
+            <div className="skeleton-content">
+              <span className="skeleton-line" />
+              <span className="skeleton-line short" />
+            </div>
+          </div>
+          <div className="canvas-section skeleton-block">
+            <div className="canvas-section-header">
+              <span className="skeleton-text skeleton-number" />
+              <span className="skeleton-text skeleton-title" />
+            </div>
+            <div className="skeleton-content">
+              <span className="skeleton-line" />
+              <span className="skeleton-line short" />
+            </div>
+          </div>
+        </div>
+
+        {/* Column 5: Customers (double height) */}
+        <div className="slc-col slc-col-double">
+          <div className="canvas-section skeleton-block">
+            <div className="canvas-section-header">
+              <span className="skeleton-text skeleton-number" />
+              <span className="skeleton-text skeleton-title" />
+            </div>
+            <div className="skeleton-content">
+              <span className="skeleton-line" />
+              <span className="skeleton-line" />
+              <span className="skeleton-line" />
+              <span className="skeleton-line short" />
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Bottom Row: Costs & Revenue */}
+      <div className="slc-row slc-row-bottom">
+        <div className="canvas-section skeleton-block">
+          <div className="canvas-section-header">
+            <span className="skeleton-text skeleton-number" />
+            <span className="skeleton-text skeleton-title" />
+          </div>
+          <div className="skeleton-content">
+            <span className="skeleton-line" />
+            <span className="skeleton-line" />
+            <span className="skeleton-line short" />
+          </div>
+        </div>
+        <div className="canvas-section skeleton-block">
+          <div className="canvas-section-header">
+            <span className="skeleton-text skeleton-number" />
+            <span className="skeleton-text skeleton-title" />
+          </div>
+          <div className="skeleton-content">
+            <span className="skeleton-line" />
+            <span className="skeleton-line" />
+            <span className="skeleton-line short" />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ToolInvocationCard.tsx
+++ b/src/components/ToolInvocationCard.tsx
@@ -1,0 +1,123 @@
+/**
+ * Tool Invocation Card - Displays tool execution in chat
+ *
+ * Shows tool name, parameters, and state (pending, executing, complete, error).
+ * Uses icons and colors to indicate tool type and status.
+ */
+
+interface ToolInvocationCardProps {
+  toolName: string;
+  toolCallId: string;
+  parameters: Record<string, unknown>;
+  state: 'pending' | 'executing' | 'complete' | 'error';
+  result?: { success?: boolean; message?: string; error?: string };
+}
+
+interface ToolDisplay {
+  icon: string;
+  label: string;
+  description: string;
+}
+
+/**
+ * Get display configuration for a tool
+ */
+function getToolDisplay(toolName: string, params: Record<string, unknown>): ToolDisplay {
+  const displays: Record<string, ToolDisplay> = {
+    update_purpose: {
+      icon: '🎯',
+      label: 'Update Purpose',
+      description: 'Updating venture purpose',
+    },
+    update_customer_section: {
+      icon: '👥',
+      label: `Update ${String(params.section || 'Section')}`,
+      description: `Updating ${String(params.section || 'customer section')}`,
+    },
+    update_economic_section: {
+      icon: '💰',
+      label: `Update ${String(params.section || 'Section')}`,
+      description: `Updating ${String(params.section || 'economic section')}`,
+    },
+    update_impact_field: {
+      icon: '🌍',
+      label: `Update ${String(params.field || 'Impact')}`,
+      description: `Updating impact ${String(params.field || 'field')}`,
+    },
+    update_key_metrics: {
+      icon: '📊',
+      label: 'Update Key Metrics',
+      description: 'Updating key metrics',
+    },
+    get_canvas: {
+      icon: '📋',
+      label: 'Get Canvas',
+      description: 'Retrieving canvas state',
+    },
+    search_methodology: {
+      icon: '📖',
+      label: 'Search Methodology',
+      description: `Searching for "${String(params.query || 'concepts')}"`,
+    },
+    search_examples: {
+      icon: '🔍',
+      label: 'Search Examples',
+      description: `Finding examples for "${String(params.query || 'ventures')}"`,
+    },
+    search_knowledge_base: {
+      icon: '🧠',
+      label: 'Search Knowledge',
+      description: `Searching knowledge base`,
+    },
+    get_venture_profile: {
+      icon: '📝',
+      label: 'Get Venture Profile',
+      description: 'Retrieving venture profile',
+    },
+  };
+
+  return displays[toolName] || {
+    icon: '🔧',
+    label: toolName.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase()),
+    description: `Executing ${toolName}`,
+  };
+}
+
+export function ToolInvocationCard({
+  toolName,
+  toolCallId,
+  parameters,
+  state,
+  result,
+}: ToolInvocationCardProps) {
+  const { icon, label, description } = getToolDisplay(toolName, parameters);
+
+  const stateIcon = {
+    pending: '⏳',
+    executing: '⚙️',
+    complete: '✓',
+    error: '✗',
+  }[state];
+
+  return (
+    <div className={`tool-card tool-card--${state}`} data-tool-id={toolCallId}>
+      <div className="tool-card-header">
+        <span className="tool-card-icon">{icon}</span>
+        <span className="tool-card-label">{label}</span>
+        <span className={`tool-card-status tool-card-status--${state}`}>
+          {stateIcon}
+        </span>
+      </div>
+
+      <div className="tool-card-description">
+        {description}
+      </div>
+
+      {state === 'error' && result?.error && (
+        <div className="tool-card-error">
+          {result.error}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/context/CanvasContext.tsx
+++ b/src/context/CanvasContext.tsx
@@ -1,0 +1,213 @@
+/**
+ * CanvasContext - Shared canvas state from agent sync
+ *
+ * The SLCAgent broadcasts canvas state via WebSocket using the Agents SDK
+ * state sync mechanism. This context bridges that state to components that
+ * need real-time canvas updates (like the Canvas component).
+ *
+ * Flow:
+ * 1. Chat connects to SLCAgent via useAgent
+ * 2. Agent broadcasts canvas state on changes (tool execution)
+ * 3. Chat receives via onStateUpdate, updates this context
+ * 4. Canvas consumes from context, merges with local edits
+ */
+
+import { createContext, useContext, useState, useCallback, type ReactNode } from 'react';
+import type { CanvasState, CanvasSectionId, ImpactModel } from '../types/canvas';
+
+/**
+ * Agent state structure (must match SLCAgent's AgentState)
+ */
+export interface AgentState {
+  status: 'idle' | 'thinking' | 'searching' | 'updating' | 'error';
+  statusMessage: string;
+  canvas: CanvasState | null;
+  canvasUpdatedAt: string | null;
+}
+
+/**
+ * Result from save operations
+ */
+export interface SaveResult {
+  success: boolean;
+  errors?: string[];
+}
+
+/**
+ * Context value shape
+ */
+interface CanvasContextValue {
+  /** Canvas state from agent sync */
+  canvas: CanvasState | null;
+  /** Last update timestamp for change detection */
+  canvasUpdatedAt: string | null;
+  /** Agent status for UI feedback */
+  agentStatus: AgentState['status'];
+  /** Agent status message */
+  agentStatusMessage: string;
+  /** Whether agent is connected */
+  isConnected: boolean;
+  /** Set of sections currently being edited locally */
+  editingSections: Set<CanvasSectionId>;
+  /** Mark a section as being edited (prevents overwrite from sync) */
+  setEditing: (section: CanvasSectionId, editing: boolean) => void;
+  /** Update from agent state sync */
+  updateFromAgent: (state: AgentState) => void;
+  /** Set connection status */
+  setConnected: (connected: boolean) => void;
+  /** Save section - returns success/failure with optional error messages */
+  saveSection: (section: CanvasSectionId, content: string, canvasId: string) => Promise<SaveResult>;
+  /** Save impact model - returns success/failure with optional error messages */
+  saveImpactModel: (impactModel: ImpactModel, canvasId: string) => Promise<SaveResult>;
+}
+
+const CanvasContext = createContext<CanvasContextValue | null>(null);
+
+/**
+ * Hook to consume canvas context
+ */
+export function useCanvasContext(): CanvasContextValue {
+  const context = useContext(CanvasContext);
+  if (!context) {
+    throw new Error('useCanvasContext must be used within CanvasProvider');
+  }
+  return context;
+}
+
+/**
+ * Provider component
+ */
+export function CanvasProvider({ children }: { children: ReactNode }) {
+  const [canvas, setCanvas] = useState<CanvasState | null>(null);
+  const [canvasUpdatedAt, setCanvasUpdatedAt] = useState<string | null>(null);
+  const [agentStatus, setAgentStatus] = useState<AgentState['status']>('idle');
+  const [agentStatusMessage, setAgentStatusMessage] = useState('');
+  const [isConnected, setIsConnected] = useState(false);
+  const [editingSections, setEditingSections] = useState<Set<CanvasSectionId>>(new Set());
+
+  // Mark section as editing/not editing
+  const setEditing = useCallback((section: CanvasSectionId, editing: boolean) => {
+    setEditingSections(prev => {
+      const next = new Set(prev);
+      if (editing) {
+        next.add(section);
+      } else {
+        next.delete(section);
+      }
+      return next;
+    });
+  }, []);
+
+  // Update from agent state sync
+  const updateFromAgent = useCallback((state: AgentState) => {
+    setAgentStatus(state.status);
+    setAgentStatusMessage(state.statusMessage);
+
+    // Only update canvas if timestamp changed (actual update)
+    if (state.canvas && state.canvasUpdatedAt !== canvasUpdatedAt) {
+      setCanvas(state.canvas);
+      setCanvasUpdatedAt(state.canvasUpdatedAt);
+    }
+  }, [canvasUpdatedAt]);
+
+  // Set connection status
+  const setConnected = useCallback((connected: boolean) => {
+    setIsConnected(connected);
+  }, []);
+
+  // Save section locally and to server
+  const saveSection = useCallback(async (
+    section: CanvasSectionId,
+    content: string,
+    canvasId: string
+  ): Promise<SaveResult> => {
+    // Persist to backend first (no more optimistic updates for accurate feedback)
+    try {
+      const response = await fetch(`/api/canvas/${canvasId}/section/${section}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ content }),
+      });
+
+      const result = await response.json() as { success: boolean; errors?: string[] };
+
+      if (result.success) {
+        // Update local state only on successful save
+        setCanvas(prev => {
+          if (!prev) return prev;
+          return {
+            ...prev,
+            sections: prev.sections.map(s =>
+              s.sectionKey === section
+                ? { ...s, content, updatedAt: new Date().toISOString() }
+                : s
+            ),
+            updatedAt: new Date().toISOString(),
+          };
+        });
+        return { success: true };
+      }
+
+      // Return validation errors
+      return { success: false, errors: result.errors };
+    } catch (err) {
+      console.error('Failed to save section:', err);
+      return { success: false, errors: ['Network error saving section'] };
+    }
+  }, []);
+
+  // Save impact model
+  const saveImpactModel = useCallback(async (
+    impactModel: ImpactModel,
+    canvasId: string
+  ): Promise<SaveResult> => {
+    // Persist to backend first
+    try {
+      const response = await fetch(`/api/canvas/${canvasId}/impact`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(impactModel),
+      });
+
+      const result = await response.json() as { success: boolean; errors?: string[] };
+
+      if (result.success) {
+        // Update local state only on successful save
+        setCanvas(prev => {
+          if (!prev) return prev;
+          return {
+            ...prev,
+            impactModel,
+            updatedAt: new Date().toISOString(),
+          };
+        });
+        return { success: true };
+      }
+
+      return { success: false, errors: result.errors };
+    } catch (err) {
+      console.error('Failed to save impact model:', err);
+      return { success: false, errors: ['Network error saving impact model'] };
+    }
+  }, []);
+
+  const value: CanvasContextValue = {
+    canvas,
+    canvasUpdatedAt,
+    agentStatus,
+    agentStatusMessage,
+    isConnected,
+    editingSections,
+    setEditing,
+    updateFromAgent,
+    setConnected,
+    saveSection,
+    saveImpactModel,
+  };
+
+  return (
+    <CanvasContext.Provider value={value}>
+      {children}
+    </CanvasContext.Provider>
+  );
+}

--- a/src/context/index.ts
+++ b/src/context/index.ts
@@ -1,0 +1,1 @@
+export { CanvasProvider, useCanvasContext, type AgentState } from './CanvasContext';

--- a/src/index.css
+++ b/src/index.css
@@ -247,6 +247,28 @@ body {
   color: #22c55e;
 }
 
+.canvas-section-status.error {
+  color: #ef4444;
+}
+
+.canvas-section.saving {
+  opacity: 0.7;
+  pointer-events: none;
+}
+
+.canvas-section.has-error {
+  border-color: #ef4444;
+}
+
+.canvas-section-error {
+  font-size: 0.75rem;
+  color: #ef4444;
+  padding: 0.25rem 0.5rem;
+  margin-bottom: 0.5rem;
+  background: rgba(239, 68, 68, 0.1);
+  border-radius: 4px;
+}
+
 .canvas-section-model {
   font-size: 0.6rem;
   font-weight: 600;
@@ -355,6 +377,37 @@ body {
   opacity: 0.9;
 }
 
+/* AI-triggered update animation */
+@keyframes sectionFlash {
+  0% {
+    box-shadow: 0 0 0 2px var(--slc-accent);
+    background-color: rgba(0, 160, 176, 0.15);
+  }
+  100% {
+    box-shadow: none;
+    background-color: var(--card-bg);
+  }
+}
+
+.canvas-section.just-updated {
+  animation: sectionFlash 1.5s ease-out;
+}
+
+[data-theme='dark'] .canvas-section.just-updated {
+  animation: sectionFlash 1.5s ease-out;
+}
+
+@keyframes sectionFlashDark {
+  0% {
+    box-shadow: 0 0 0 2px var(--slc-accent);
+    background-color: rgba(0, 160, 176, 0.2);
+  }
+  100% {
+    box-shadow: none;
+    background-color: var(--card-bg);
+  }
+}
+
 /* ============================================
    Chat
    ============================================ */
@@ -442,6 +495,19 @@ body {
 
 .chat-input::placeholder {
   color: var(--text-muted);
+}
+
+/* Dynamic textarea input */
+.chat-textarea {
+  resize: none;
+  overflow: hidden;
+  min-height: 2.5rem;
+  max-height: 200px;
+  line-height: 1.4;
+}
+
+.chat-textarea:focus {
+  overflow-y: auto;
 }
 
 .chat-send {
@@ -766,4 +832,325 @@ body {
   overflow: hidden;
   clip: rect(0, 0, 0, 0);
   border: 0;
+}
+
+/* ============================================
+   Skeleton Loading States
+   ============================================ */
+
+.slc-canvas.skeleton {
+  pointer-events: none;
+}
+
+.skeleton-block {
+  background: var(--card-bg);
+}
+
+.skeleton-text {
+  display: inline-block;
+  background: linear-gradient(
+    90deg,
+    var(--bg-tertiary) 25%,
+    var(--border-color) 50%,
+    var(--bg-tertiary) 75%
+  );
+  background-size: 200% 100%;
+  animation: skeleton-shimmer 1.5s ease-in-out infinite;
+  border-radius: 4px;
+}
+
+.skeleton-number {
+  width: 1.5rem;
+  height: 1rem;
+}
+
+.skeleton-title {
+  width: 6rem;
+  height: 1rem;
+}
+
+.skeleton-content {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 0.5rem 0;
+}
+
+.skeleton-line {
+  display: block;
+  height: 0.875rem;
+  background: linear-gradient(
+    90deg,
+    var(--bg-tertiary) 25%,
+    var(--border-color) 50%,
+    var(--bg-tertiary) 75%
+  );
+  background-size: 200% 100%;
+  animation: skeleton-shimmer 1.5s ease-in-out infinite;
+  border-radius: 4px;
+  width: 100%;
+}
+
+.skeleton-line.short {
+  width: 60%;
+}
+
+@keyframes skeleton-shimmer {
+  0% {
+    background-position: 200% 0;
+  }
+  100% {
+    background-position: -200% 0;
+  }
+}
+
+/* ============================================
+   Canvas Error State
+   ============================================ */
+
+.canvas-error-container {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.canvas-error {
+  color: #e53e3e;
+  text-align: center;
+}
+
+.canvas-error-retry {
+  margin-top: 1rem;
+  padding: 0.5rem 1rem;
+  background: var(--accent-color);
+  color: white;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 0.875rem;
+}
+
+.canvas-error-retry:hover {
+  background: var(--accent-hover);
+}
+
+/* ============================================
+   Responsive / Mobile Layout
+   ============================================ */
+
+@media (max-width: 768px) {
+  /* Stack canvas and chat vertically */
+  .app-main {
+    flex-direction: column;
+  }
+
+  .layout-canvas {
+    flex: none;
+    width: 100%;
+    height: 55vh;
+    border-right: none;
+    border-bottom: 1px solid var(--border-color);
+    padding: 0.5rem;
+  }
+
+  .layout-chat {
+    flex: none;
+    width: 100%;
+    height: 45vh;
+  }
+
+  /* Reduce canvas gap on mobile */
+  .slc-canvas {
+    gap: 1px;
+  }
+
+  .slc-row {
+    gap: 1px;
+  }
+
+  .slc-col {
+    gap: 1px;
+  }
+
+  /* Smaller section padding */
+  .canvas-section {
+    padding: 0.5rem;
+  }
+
+  .canvas-section-header {
+    gap: 0.25rem;
+    font-size: 0.65rem;
+  }
+
+  .canvas-section-number {
+    font-size: 0.7rem;
+    width: 1rem;
+    height: 1rem;
+  }
+
+  .canvas-section-model {
+    font-size: 0.5rem;
+    padding: 0.1rem 0.25rem;
+  }
+
+  .canvas-section-content {
+    font-size: 0.75rem;
+  }
+
+  /* Reduce row heights on mobile */
+  .slc-row-top {
+    min-height: 80px;
+  }
+
+  .slc-row-middle {
+    min-height: 180px;
+  }
+
+  .slc-row-bottom {
+    min-height: 60px;
+  }
+
+  /* Chat adjustments */
+  .chat-header {
+    padding: 0.5rem;
+  }
+
+  .chat-messages {
+    padding: 0.5rem;
+  }
+
+  .chat-message {
+    padding: 0.5rem 0.75rem;
+    font-size: 0.85rem;
+  }
+
+  .chat-input-container {
+    padding: 0.5rem;
+  }
+
+  .chat-input {
+    padding: 0.5rem 0.75rem;
+    font-size: 0.85rem;
+  }
+
+  .chat-send {
+    padding: 0.5rem 0.75rem;
+    font-size: 0.85rem;
+  }
+
+  /* Header adjustments */
+  .app-header {
+    padding: 0.5rem 1rem;
+  }
+
+  .app-header h1 {
+    font-size: 1rem;
+  }
+}
+
+/* ============================================
+   Tool Invocation Cards
+   ============================================ */
+
+.tool-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  padding: 0.5rem 0.75rem;
+  margin: 0.5rem 0;
+  background: var(--bg-tertiary);
+  border-radius: 6px;
+  border-left: 3px solid var(--border-color);
+  font-size: 0.85rem;
+}
+
+.tool-card--pending {
+  border-left-color: #f59e0b;
+  opacity: 0.8;
+}
+
+.tool-card--executing {
+  border-left-color: #3b82f6;
+}
+
+.tool-card--complete {
+  border-left-color: #22c55e;
+}
+
+.tool-card--error {
+  border-left-color: #ef4444;
+}
+
+.tool-card-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.tool-card-icon {
+  font-size: 1rem;
+}
+
+.tool-card-label {
+  font-weight: 500;
+  color: var(--text-primary);
+}
+
+.tool-card-status {
+  margin-left: auto;
+  font-size: 0.875rem;
+}
+
+.tool-card-status--complete {
+  color: #22c55e;
+}
+
+.tool-card-status--error {
+  color: #ef4444;
+}
+
+.tool-card-status--executing {
+  color: #3b82f6;
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+
+.tool-card-description {
+  color: var(--text-secondary);
+  font-size: 0.8rem;
+}
+
+.tool-card-error {
+  color: #ef4444;
+  font-size: 0.8rem;
+  margin-top: 0.25rem;
+}
+
+/* Extra small screens */
+@media (max-width: 480px) {
+  .layout-canvas {
+    height: 50vh;
+  }
+
+  .layout-chat {
+    height: 50vh;
+  }
+
+  /* Stack middle columns on very small screens */
+  .slc-row-middle {
+    flex-wrap: wrap;
+  }
+
+  .slc-col {
+    flex: 1 1 calc(50% - 1px);
+    min-width: calc(50% - 1px);
+  }
+
+  .slc-col-double {
+    flex: 1 1 100%;
+  }
 }

--- a/worker/agents/prompts.ts
+++ b/worker/agents/prompts.ts
@@ -71,7 +71,44 @@ export function formatCanvasContext(canvas: {
   };
 } | null): string {
   if (!canvas) {
-    return 'No canvas selected. The user should create or select a canvas first.';
+    return 'Error: No canvas is loaded. This is unexpected - please have the user refresh the page.';
+  }
+
+  // Check if canvas is completely empty (new canvas)
+  const mainSections = [
+    canvas.purpose,
+    canvas.customers,
+    canvas.jobsToBeDone,
+    canvas.valueProposition,
+    canvas.solution,
+    canvas.channels,
+    canvas.revenue,
+    canvas.costs,
+    canvas.advantage,
+    canvas.keyMetrics,
+  ];
+  const impactFields = canvas.impactModel ? [
+    canvas.impactModel.issue,
+    canvas.impactModel.participants,
+    canvas.impactModel.activities,
+    canvas.impactModel.outputs,
+    canvas.impactModel.shortTermOutcomes,
+    canvas.impactModel.mediumTermOutcomes,
+    canvas.impactModel.longTermOutcomes,
+    canvas.impactModel.impact,
+  ] : [];
+
+  const hasAnyContent = [...mainSections, ...impactFields].some(s => s && s.trim().length > 0);
+
+  if (!hasAnyContent) {
+    return `This is a brand new canvas - all sections are empty.
+
+The user is just getting started with their Social Lean Canvas. Your task is to:
+1. Welcome them warmly and learn about their social venture idea
+2. Ask about the problem they want to solve and who they want to help
+3. Once you understand their idea, use the update_purpose tool to capture their purpose
+
+Start with a natural, friendly conversation. Do NOT list all the sections or overwhelm them with structure - just ask about their idea and let the conversation flow naturally.`;
   }
 
   const sections: string[] = [];

--- a/worker/routes/canvas.ts
+++ b/worker/routes/canvas.ts
@@ -107,7 +107,9 @@ export async function handleCanvasRoute(
       }
 
       const result = await stub.updateSection(sectionKey as CanvasSectionId, body.content);
-      return jsonResponse(result, 200, requestId);
+      // Return 422 Unprocessable Entity for validation failures
+      const status = result.success ? 200 : 422;
+      return jsonResponse(result, status, requestId);
     }
 
     // PUT /api/canvas/:id/impact - Update full impact model


### PR DESCRIPTION
## Summary

- Add save state tracking to canvas sections with proper validation feedback
- Fix empty canvas handling so agent guides users naturally instead of saying "no canvas"
- Add real-time canvas state sync between Chat and Canvas components
- Return proper HTTP status codes (422) for validation failures

## Changes

### Canvas UI
- **CanvasSection**: Track save state (idle/saving/saved/error), show validation errors inline
- **Canvas**: Update to use CanvasContext for state sync with agent
- **CanvasSkeleton**: New loading placeholder component

### Agent/Chat
- **CanvasContext**: New shared state provider for canvas sync between components
- **Chat**: Integrate with CanvasContext, add StatusBar and ConnectionStatus
- **ToolInvocationCard**: New component to display AI tool invocations
- **prompts.ts**: Better guidance for empty canvases

### Backend
- **canvas.ts**: Return 422 for validation failures instead of always 200
- **SLCAgent.ts**: Broadcast canvas state to clients, add canvas to agent state
- **anthropic-tools.ts**: Add broadcast after tool execution

## Test plan

- [ ] Create new session, verify welcome message appears
- [ ] Send message to agent, verify it responds with canvas context
- [ ] Edit canvas section with < 20 chars, verify error message appears
- [ ] Edit canvas section with valid content, verify green check after save
- [ ] Verify agent sees canvas updates on next message

🤖 Generated with [Claude Code](https://claude.com/claude-code)